### PR TITLE
Add screens /splash and /start

### DIFF
--- a/src/components/Background/ResponsiveSvgBackground.tsx
+++ b/src/components/Background/ResponsiveSvgBackground.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import classnames from "classnames";
+import { useWindowSize } from "~/lib/hooks";
+
+type Props = {
+  children: React.ReactNode;
+  height: number;
+  width: number;
+} & React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+/**
+ * We sometimes use SVGs to visually upgrade certain screens of our app.
+ * However, each user device may have a different screen size. Since we are using SVGs
+ * we can simply resize them based on the device's screen size.
+ *
+ * This component takes care of the resizing and makes sure the SVGs width-to-height ratio is met.
+ * The background is fixed to the bottom by default unless custom classNames have been passed as props.
+ *
+ * @param props.height The SVG's default height defined in its `viewBox` prop.
+ * @param props.width The SVG's default width defined in its `viewBox` prop.
+ * @param props.children The content of the SVG excluding the `<svg />` tag.
+ */
+const ResponsiveSvgBackground = ({
+  children,
+  height,
+  width,
+  className,
+  ...rest
+}: Props) => {
+  const size = useWindowSize();
+  const backgroundRatio = width / height;
+  const svgHeight = size.width / backgroundRatio;
+  const css = classnames({ "fixed bottom-0 left-0": !className });
+
+  return (
+    <div className={css} {...rest}>
+      <svg
+        width={size.width}
+        height={svgHeight}
+        viewBox={`0 0 ${width} ${height}`}
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {children}
+      </svg>
+    </div>
+  );
+};
+
+export default ResponsiveSvgBackground;

--- a/src/components/Background/index.ts
+++ b/src/components/Background/index.ts
@@ -1,0 +1,1 @@
+export { default as ResponsiveSvgBackground } from "./ResponsiveSvgBackground";

--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -19,7 +19,7 @@ const Steps = ({ steps, children }: Props) => {
     <>
       <StepsBar />
       <ActiveStepContent />
-      {children(rest)}
+      {children && children(rest)}
     </>
   );
 };

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useMobileDevice } from "./useMobileDevice";
+export { useWindowSize } from "./useWindowSize";

--- a/src/lib/hooks/useWindowSize.ts
+++ b/src/lib/hooks/useWindowSize.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+// Source: https://usehooks.com/useWindowSize/
+export function useWindowSize() {
+  const isClient = typeof window === "object";
+
+  function getSize() {
+    return {
+      width: isClient ? window.innerWidth : undefined,
+      height: isClient ? window.innerHeight : undefined
+    };
+  }
+
+  const [windowSize, setWindowSize] = useState(getSize);
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+
+    function handleResize() {
+      setWindowSize(getSize());
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []); // Empty array ensures that effect is only run on mount and unmount
+
+  return windowSize;
+}

--- a/src/pages/public/SplashScreen.tsx
+++ b/src/pages/public/SplashScreen.tsx
@@ -1,68 +1,35 @@
 import React from "react";
-import { Logo } from "~/components/Logo";
-import { useWindowSize } from "~/lib/hooks";
-
-type Props = {};
-
-// ratio of background svg (reference: viewBox prop): width / height
-const BACKGROUND_RATIO = 360 / 201;
-const LOGO_DEFAULT_WIDTH = 40;
-// The logo is designed for a base screen width
-const LOGO_BASE_SCREEN_WIDTH = 360;
+import { ResponsiveSvgBackground } from "~/components/Background";
+import { ResponsiveLandingTitle } from "./components";
 
 /**
  * The splash screen is shown when the app starts on a mobile device.
  */
-const SplashScreen = ({}: Props) => {
-  const size = useWindowSize();
-  const height = size.width / BACKGROUND_RATIO;
-  const logoRatio = Math.max(size.width / LOGO_BASE_SCREEN_WIDTH, 1);
-  // The bottom background counts as "taken" space.
-  // We therefore want to pull the main part up using the negative margin trick,
-  // to make sure it appears vertically centered.
-  const MarginStyles = { marginTop: -height };
-  console.log({ logoRatio });
+const SplashScreen = () => {
   return (
     <>
-      <div className="flex items-center h-full">
+      <div className="relative z-10 flex items-center h-full">
         {/* Logo and subtitle */}
-        <div className="w-full text-center" style={MarginStyles}>
-          <Logo
-            size={logoRatio * LOGO_DEFAULT_WIDTH}
-            withText
-            className="mx-auto mb-4 md:mb-8"
-          />
-          <p className="text-brand sm:text-lg md:text-2xl">
-            Landwirt*innen und <br /> Helfer*innen verbinden.
-          </p>
-        </div>
+        <ResponsiveLandingTitle />
       </div>
 
       {/* Bottom background */}
-      <div className="fixed bottom-0 left-0">
-        <svg
-          width={size.width}
-          height={height}
-          viewBox="0 0 360 201"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            opacity="0.5"
-            d="M207 0C146.2 0 50.6667 16 0 24V322H496V16C454.333 10.6667 267.8 0 207 0Z"
-            fill="#DCB38E"
-          />
-          <path
-            d="M160 58C81.6 58 24.3333 79.3333 -5 95V282H473V52C458.333 62.6667 374.2 81 339 81C295 81 258 58 160 58Z"
-            fill="#94E1AE"
-          />
-          <path
-            opacity="0.5"
-            d="M217 89C138.6 89 21.3333 110.333 -8 126V330H477C484.2 330 480 165.667 477 89C462.333 99.6667 397.2 111 362 111C318 111 315 89 217 89Z"
-            fill="#197649"
-          />
-        </svg>
-      </div>
+      <ResponsiveSvgBackground width={360} height={201}>
+        <path
+          opacity="0.5"
+          d="M207 0C146.2 0 50.6667 16 0 24V322H496V16C454.333 10.6667 267.8 0 207 0Z"
+          fill="#DCB38E"
+        />
+        <path
+          d="M160 58C81.6 58 24.3333 79.3333 -5 95V282H473V52C458.333 62.6667 374.2 81 339 81C295 81 258 58 160 58Z"
+          fill="#94E1AE"
+        />
+        <path
+          opacity="0.5"
+          d="M217 89C138.6 89 21.3333 110.333 -8 126V330H477C484.2 330 480 165.667 477 89C462.333 99.6667 397.2 111 362 111C318 111 315 89 217 89Z"
+          fill="#197649"
+        />
+      </ResponsiveSvgBackground>
     </>
   );
 };

--- a/src/pages/public/SplashScreen.tsx
+++ b/src/pages/public/SplashScreen.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Logo } from "~/components/Logo";
+import { useWindowSize } from "~/lib/hooks";
+
+type Props = {};
+
+// ratio of background svg (reference: viewBox prop): width / height
+const BACKGROUND_RATIO = 360 / 201;
+const LOGO_DEFAULT_WIDTH = 40;
+// The logo is designed for a base screen width
+const LOGO_BASE_SCREEN_WIDTH = 360;
+
+/**
+ * The splash screen is shown when the app starts on a mobile device.
+ */
+const SplashScreen = ({}: Props) => {
+  const size = useWindowSize();
+  const height = size.width / BACKGROUND_RATIO;
+  const logoRatio = Math.max(size.width / LOGO_BASE_SCREEN_WIDTH, 1);
+  // The bottom background counts as "taken" space.
+  // We therefore want to pull the main part up using the negative margin trick,
+  // to make sure it appears vertically centered.
+  const MarginStyles = { marginTop: -height };
+  console.log({ logoRatio });
+  return (
+    <>
+      <div className="flex items-center h-full">
+        {/* Logo and subtitle */}
+        <div className="w-full text-center" style={MarginStyles}>
+          <Logo
+            size={logoRatio * LOGO_DEFAULT_WIDTH}
+            withText
+            className="mx-auto mb-4 md:mb-8"
+          />
+          <p className="text-brand sm:text-lg md:text-2xl">
+            Landwirt*innen und <br /> Helfer*innen verbinden.
+          </p>
+        </div>
+      </div>
+
+      {/* Bottom background */}
+      <div className="fixed bottom-0 left-0">
+        <svg
+          width={size.width}
+          height={height}
+          viewBox="0 0 360 201"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            opacity="0.5"
+            d="M207 0C146.2 0 50.6667 16 0 24V322H496V16C454.333 10.6667 267.8 0 207 0Z"
+            fill="#DCB38E"
+          />
+          <path
+            d="M160 58C81.6 58 24.3333 79.3333 -5 95V282H473V52C458.333 62.6667 374.2 81 339 81C295 81 258 58 160 58Z"
+            fill="#94E1AE"
+          />
+          <path
+            opacity="0.5"
+            d="M217 89C138.6 89 21.3333 110.333 -8 126V330H477C484.2 330 480 165.667 477 89C462.333 99.6667 397.2 111 362 111C318 111 315 89 217 89Z"
+            fill="#197649"
+          />
+        </svg>
+      </div>
+    </>
+  );
+};
+
+export default SplashScreen;

--- a/src/pages/public/StartScreen.tsx
+++ b/src/pages/public/StartScreen.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { PrimaryButton } from "~/components/Button";
+import { ResponsiveSvgBackground } from "~/components/Background";
+import { ResponsiveLandingTitle } from "./components";
+
+const ResetTopMarginStyles = { marginTop: 0 };
+
+const StartScreen = () => {
+  return (
+    <>
+      <div className="relative z-10 flex flex-col h-full px-4">
+        {/* Logo and subtitle */}
+        <div className="flex-grow">
+          <div className="flex items-center h-full">
+            <ResponsiveLandingTitle
+              className="block mb-16"
+              style={ResetTopMarginStyles}
+            />
+          </div>
+        </div>
+
+        {/* C2A buttons */}
+        <div className="w-full block pb-4">
+          <PrimaryButton block className="tracking-wider mb-2">
+            Ich will helfen
+          </PrimaryButton>
+          <PrimaryButton block className="tracking-wider">
+            Ich benötige Hilfe
+          </PrimaryButton>
+
+          <p className="mt-12 mb-2 text-center text-sm">
+            Oder hast du schon einen Account?
+          </p>
+          <PrimaryButton block theme="border" className="tracking-wider">
+            Anmelden
+          </PrimaryButton>
+        </div>
+      </div>
+
+      {/* Bottom background */}
+      <ResponsiveSvgBackground width={360} height={201}>
+        <g opacity="0.2">
+          <path
+            opacity="0.5"
+            d="M98 0C37.2 0 -58.3333 16 -109 24V322H387V16C345.333 10.6667 158.8 0 98 0Z"
+            fill="#DCB38E"
+          />
+          <path
+            d="M51 58C-27.4 58 -84.6667 79.3333 -114 95V282H364V52C349.333 62.6667 265.2 81 230 81C186 81 149 58 51 58Z"
+            fill="#94E1AE"
+          />
+          <path
+            opacity="0.5"
+            d="M108 89C29.6 89 -87.6667 110.333 -117 126V330H368C375.2 330 371 165.667 368 89C353.333 99.6667 288.2 111 253 111C209 111 206 89 108 89Z"
+            fill="#197649"
+          />
+        </g>
+      </ResponsiveSvgBackground>
+    </>
+  );
+};
+
+export default StartScreen;

--- a/src/pages/public/components/ResponsiveLandingTitle.tsx
+++ b/src/pages/public/components/ResponsiveLandingTitle.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import classnames from "classnames";
+import { useWindowSize } from "~/lib/hooks";
+import { Logo } from "~/components/Logo";
+
+type Props = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+// ratio of background svg (reference: viewBox prop): width / height
+const BACKGROUND_RATIO = 360 / 201;
+const LOGO_DEFAULT_WIDTH = 40;
+// The logo is designed for a base screen width
+const LOGO_BASE_SCREEN_WIDTH = 360;
+
+/**
+ * The brand's word mark and a subtitle shown on landing pages.
+ * The logo's and title's size are automatically adapting to the screen size
+ * and are placed on the middle of the screen in relation to the background's height.
+ */
+const ResponsiveLandingTitle = ({ className, style, ...rest }: Props) => {
+  const size = useWindowSize();
+  const height = size.width / BACKGROUND_RATIO;
+  const logoRatio = Math.max(size.width / LOGO_BASE_SCREEN_WIDTH, 1);
+  // The bottom background counts as "taken" space.
+  // We therefore want to pull the main part up using the negative margin trick,
+  // to make sure it appears vertically centered.
+  const styles = { marginTop: -height, ...style };
+
+  return (
+    <div
+      className={classnames("w-full text-center", className)}
+      style={styles}
+      {...rest}
+    >
+      <Logo
+        size={logoRatio * LOGO_DEFAULT_WIDTH}
+        withText
+        className="mx-auto mb-4 md:mb-8"
+      />
+      <p className="text-brand sm:text-lg md:text-2xl">
+        Landwirt*innen und <br /> Helfer*innen verbinden.
+      </p>
+    </div>
+  );
+};
+
+export default ResponsiveLandingTitle;

--- a/src/pages/public/components/index.ts
+++ b/src/pages/public/components/index.ts
@@ -1,0 +1,1 @@
+export { default as ResponsiveLandingTitle } from "./ResponsiveLandingTitle";

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,6 +5,7 @@ import BoardingFarmer from "../pages/public/BoardingFarmer";
 import Home from "./../pages/public/Home";
 import Map from "./../pages/public/Map";
 import SplashScreen from "~/pages/public/SplashScreen";
+import StartScreen from "~/pages/public/StartScreen";
 
 export default function AppRoutes() {
   return (
@@ -19,6 +20,7 @@ export default function AppRoutes() {
 
       {/* Screens - only for presentational purposes */}
       <Route exact path="/screens/splash" component={SplashScreen} />
+      <Route exact path="/screens/start" component={StartScreen} />
 
       {/*Redirect*/}
       <Redirect

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,7 @@ import NotFoundPage from "../pages/error/NotFound";
 import BoardingFarmer from "../pages/public/BoardingFarmer";
 import Home from "./../pages/public/Home";
 import Map from "./../pages/public/Map";
+import SplashScreen from "~/pages/public/SplashScreen";
 
 export default function AppRoutes() {
   return (
@@ -15,6 +16,9 @@ export default function AppRoutes() {
       <Route exact path="/boarding-farmer" component={BoardingFarmer} />
 
       <Route exact path="/404" component={NotFoundPage} />
+
+      {/* Screens - only for presentational purposes */}
+      <Route exact path="/screens/splash" component={SplashScreen} />
 
       {/*Redirect*/}
       <Redirect

--- a/src/styles/_layout.css
+++ b/src/styles/_layout.css
@@ -1,0 +1,9 @@
+html,
+body,
+#root {
+  @apply h-full;
+}
+
+body {
+  @apply font-body;
+}

--- a/src/styles/main.src.css
+++ b/src/styles/main.src.css
@@ -3,6 +3,9 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+/* Core */
+@import "./_layout.css";
+
 /* Components */
 @import "../components/Form/Form.css";
 @import "../components/Steps/Steps.css";


### PR DESCRIPTION
**Adds**
- `useWindowSize` hook to get screen size of window
- `<ResponsiveSvgBackground />` to automatically fit SVG backgrounds to screen size of user's device
- screen **Splash** (named in Figma) (route: `/screens/splash`)
- screen **Start** (named in Figma) (route: `/screens/start`)

**Updates**
- layout css to fit `html`, `body` and `#root` to full height by default

**Fixes**
- critical bug inside `src/components/Steps/Steps.tsx`